### PR TITLE
Include font package in addition to fontFamily in TextPainter

### DIFF
--- a/lib/gradient_icon.dart
+++ b/lib/gradient_icon.dart
@@ -95,6 +95,7 @@ class _GradientIconPainter extends CustomPainter {
           foreground:
               gradientShaderPaint, // Apply the gradient shader as the foreground color
           fontFamily: icon!.fontFamily, // Set the icon's font family
+          package: icon!.fontPackage, // Set the icon's font package
           fontSize: iconSize, // Set the icon's size
         ),
       ),


### PR DESCRIPTION
Solves #2 and #3. This edit fixes a bug which caused some icon packs to get rendered incorrectly, because the font package was not included in the creation of `TextPainter`s.